### PR TITLE
Add docker-sync support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /.v8flags*
 /apps/*
 /.babel.json
+/infra/dev/.docker-sync*

--- a/README.md
+++ b/README.md
@@ -24,6 +24,25 @@ You'll find:
 - Admin panel at `http://localhost/admin` (Login : `sylius`, password: `sylius`).
 - Your mails at `http://localhost:1080`.
 
+## Setup with `docker-sync`
+
+### Install `docker-sync`
+
+https://github.com/EugenMayer/docker-sync/wiki/1.-Installation
+
+### Up containers
+
+`make up SYNC=1`
+
+### Down containers
+
+`make down SYNC=1`
+
+### Improvements ?
+
+On a fresh Sylius setup, you will see no differences. But when you add your custom bundles and plugins, the platform can be slow on Mac OS.
+To avoid that docker-sync help you to improve the speed of your customized Sylius platform.
+
 ## Change Sylius folder dir
 
 You can to change the target dir (`apps/sylius` by default):

--- a/infra/dev/docker-compose-sync.yml
+++ b/infra/dev/docker-compose-sync.yml
@@ -1,0 +1,56 @@
+version: '3'
+
+services:
+  php:
+    build:
+      context: php
+      args:
+        USER_UID: ${USER_UID}
+    environment:
+      - SYLIUS_APP_DEV_PERMITTED=1
+    volumes:
+      - sylius_sync:/var/www:nocopy
+      - ../../apps/sylius/var:/var/www/apps/sylius/var:cached
+      - ../../apps/sylius/vendor:/var/www/apps/sylius/vendor:cached
+      - ../../apps/sylius/web/media:/var/www/apps/sylius/web/media:cached
+      - ~/.composer:/var/www/.composer:rw,cached
+    links:
+      - db
+      - mail
+    ports:
+      - "80:80"
+#      - "8080:8080"
+
+  db:
+    image: monsieurbiz/mariadb:10.1
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: sylius
+    volumes:
+      - database:/var/lib/mysql:rw,cached
+    ports:
+      - "3306:3306"
+
+  node:
+    build:
+      context: node/
+      args:
+        USER_UID: ${USER_UID}
+    volumes:
+      - ../../:/var/www:rw,cached
+
+  mail:
+    image: monsieurbiz/mailcatcher
+    ports:
+      - "1080:1080"
+
+  blackfire:
+    image: blackfire/blackfire
+    environment:
+      - BLACKFIRE_SERVER_ID
+      - BLACKFIRE_SERVER_TOKEN
+
+volumes:
+  database: {}
+  sylius_sync:
+    external: true

--- a/infra/dev/docker-sync.yml
+++ b/infra/dev/docker-sync.yml
@@ -1,0 +1,38 @@
+version: '2'
+options:
+  verbose: true
+syncs:
+  sylius_sync:
+    src: '../..'
+    sync_prefer: 'newer'
+    sync_userid: ${USER_UID}
+    sync_excludes: [
+      '.idea',
+      '.github',
+      '.yarn',
+      '.composer',
+      '.cache',
+      '.hologram',
+      'node_modules',
+      '.gitignore',
+      '.git',
+      '.DS_Store',
+      'apps/sylius/var',
+      'apps/sylius/vendor',
+      'apps/sylius/web/media'
+    ]
+    watch_excludes: [
+      '.idea',
+      '.github',
+      '.yarn',
+      '.composer',
+      '.cache',
+      '.hologram',
+      'node_modules',
+      '.gitignore',
+      '.git',
+      '.DS_Store',
+      'apps/sylius/var',
+      'apps/sylius/vendor',
+      'apps/sylius/web/media'
+    ]


### PR DESCRIPTION
## Prerequisites

### Install `docker-sync`

https://github.com/EugenMayer/docker-sync/wiki/1.-Installation

## How to use it

Use `make up SYNC=1` to up the project with a specific docker-compose file and docker-sync
You can find the log of synced files in `infra/dev/.docker-sync/daemon.log`

To down the project use `make down SYNC=1`

## Synced files

You can see all ignored folder by docker sync in `infra/dev/docker-sync.yml`
In Sylius application folder, 3 folders are ignored : 
- apps/sylius/var
- apps/sylius/vendor
- apps/sylius/web/media

We ignore also all folders/files we don't need to have like : 
- .idea
- .github
- node_modules
etc.

When you edit a synced file, the synchronization is really fast and the time to go to your favorite browser and refresh the page is sufficient.