### PR TITLE
Symfony bin not in path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,6 @@ logs: docker.logs symfony.server.log ## Logs
 # ¯¯¯¯¯¯¯¯¯
 
 coffee: ## Launch it, and take coffee ☕️
-	${MAKE} add-symfony-bin
 	${MAKE} project.infra.update
 	mkdir -p apps/${SYLIUS_FOLDER}
 	rm -f .php-version

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ rm -rf .git
 git init
 git add .
 git commit -m "Init project with Sylius infra"
+make add-symfony-bin
+sudo cp ${HOME}/.symfony/bin/symfony /usr/local/bin/
 make coffee
 ```
 


### PR DESCRIPTION
If you run `make coffee` and don't have the symfony bin in the path, an error is thrown.

I changed the README and the Makefile to:

1. Download symfony bin
2. Copy it in bin directory
3. Launch `make coffee`